### PR TITLE
Team delete uow

### DIFF
--- a/features/team/server/Garnet.Teams.AcceptanceTests/Startup.cs
+++ b/features/team/server/Garnet.Teams.AcceptanceTests/Startup.cs
@@ -30,6 +30,8 @@ namespace Garnet.Teams.AcceptanceTests
             services.AddScoped<ITeamUserRepository, TeamUserRepository>();
             services.AddScoped<ITeamUserJoinRequestRepository, TeamUserJoinRequestRepository>();
 
+            services.AddScoped<TeamDeleteUnitOfWork>();
+
             services.AddScoped<TeamService>();
             services.AddScoped<TeamUserService>();
             services.AddScoped<TeamParticipantService>();

--- a/features/team/server/Garnet.Teams.Application/ITeamParticipantRepository.cs
+++ b/features/team/server/Garnet.Teams.Application/ITeamParticipantRepository.cs
@@ -4,7 +4,7 @@ namespace Garnet.Teams.Application
     {
         Task<TeamParticipant> CreateTeamParticipant(CancellationToken ct, string userId, string username, string teamId);
         Task<TeamParticipant[]> GetParticipantsFromTeam(CancellationToken ct, string teamId);
-        Task<TeamParticipant[]> DeleteTeamParticipants(CancellationToken ct, string teamId);
+        Task DeleteParticipantsByTeam(CancellationToken ct, string teamId);
         Task<TeamParticipant[]> GetMembershipOfUser(CancellationToken ct, string userId);
         Task<TeamParticipant[]> FilterTeamParticipants(CancellationToken ct, TeamUserFilterArgs filter);
         Task UpdateTeamParticipant(CancellationToken ct, string userId, TeamParticipantUpdateArgs update);

--- a/features/team/server/Garnet.Teams.Application/ITeamUserJoinRequestRepository.cs
+++ b/features/team/server/Garnet.Teams.Application/ITeamUserJoinRequestRepository.cs
@@ -4,5 +4,6 @@ namespace Garnet.Teams.Application
     {
         Task<TeamUserJoinRequest> CreateJoinRequestByUser(CancellationToken ct, string userId, string teamId);
         Task<TeamUserJoinRequest[]> GetAllUserJoinRequestsByTeam(CancellationToken ct, string teamId);
+        Task DeleteUserJoinRequestsByTeam(CancellationToken ct, string teamId);
     }
 }

--- a/features/team/server/Garnet.Teams.Application/TeamDeleteUnitOfWork.cs
+++ b/features/team/server/Garnet.Teams.Application/TeamDeleteUnitOfWork.cs
@@ -1,0 +1,38 @@
+using FluentResults;
+using Garnet.Common.Application;
+
+namespace Garnet.Teams.Application
+{
+    public class TeamDeleteUnitOfWork
+    {
+        private readonly TeamService _teamService;
+        private readonly TeamParticipantService _participantService;
+        private readonly TeamUserJoinRequestService _userJoinRequestService;
+
+        public TeamDeleteUnitOfWork(
+            TeamService teamService,
+            TeamParticipantService participantService,
+            TeamUserJoinRequestService userJoinRequestService)
+        {
+            _teamService = teamService;
+            _participantService = participantService;
+            _userJoinRequestService = userJoinRequestService;
+        }
+
+        public async Task<Result<Team>> DeleteTeam(CancellationToken ct, ICurrentUserProvider currentUserProvider, string teamId)
+        {
+            var deleteTeam = await _teamService.DeleteTeam(ct, teamId, currentUserProvider);
+
+            if (deleteTeam.IsFailed)
+            {
+                return Result.Fail(deleteTeam.Errors);
+            }
+
+            var team = deleteTeam.Value;
+            await _participantService.DeleteTeamParticipants(ct, team.Id);
+            await _userJoinRequestService.DeleteUserJoinRequestsByTeam(ct, team.Id);
+
+            return Result.Ok(team);
+        }
+    }
+}

--- a/features/team/server/Garnet.Teams.Application/TeamParticipantService.cs
+++ b/features/team/server/Garnet.Teams.Application/TeamParticipantService.cs
@@ -30,9 +30,9 @@ namespace Garnet.Teams.Application
             return Result.Ok(participant);
         }
 
-        public async Task<TeamParticipant[]> DeleteTeamParticipants(CancellationToken ct, string teamId)
+        public async Task DeleteTeamParticipants(CancellationToken ct, string teamId)
         {
-            return await _teamParticipantsRepository.DeleteTeamParticipants(ct, teamId);
+            await _teamParticipantsRepository.DeleteParticipantsByTeam(ct, teamId);
         }
 
         public async Task<TeamParticipant[]> GetMembershipOfUser(CancellationToken ct, string userId)

--- a/features/team/server/Garnet.Teams.Application/TeamService.cs
+++ b/features/team/server/Garnet.Teams.Application/TeamService.cs
@@ -9,14 +9,17 @@ namespace Garnet.Teams.Application
     {
         private readonly ITeamRepository _teamRepository;
         private readonly TeamParticipantService _participantService;
+        private readonly TeamUserJoinRequestService _userJoinRequestService;
         private readonly TeamUserService _userService;
         public TeamService(ITeamRepository teamRepository,
                            TeamParticipantService participantService,
+                           TeamUserJoinRequestService userJoinRequestService,
                            TeamUserService userService)
         {
             _participantService = participantService;
             _teamRepository = teamRepository;
             _userService = userService;
+            _userJoinRequestService = userJoinRequestService;
         }
 
         public async Task<Result<Team>> CreateTeam(CancellationToken ct, string name, string description, string[] tags, ICurrentUserProvider currentUserProvider)
@@ -60,8 +63,6 @@ namespace Garnet.Teams.Application
             }
 
             await _teamRepository.DeleteTeam(ct, teamId);
-            await _participantService.DeleteTeamParticipants(ct, teamId);
-
             return Result.Ok(team);
         }
 

--- a/features/team/server/Garnet.Teams.Application/TeamService.cs
+++ b/features/team/server/Garnet.Teams.Application/TeamService.cs
@@ -9,17 +9,14 @@ namespace Garnet.Teams.Application
     {
         private readonly ITeamRepository _teamRepository;
         private readonly TeamParticipantService _participantService;
-        private readonly TeamUserJoinRequestService _userJoinRequestService;
         private readonly TeamUserService _userService;
         public TeamService(ITeamRepository teamRepository,
                            TeamParticipantService participantService,
-                           TeamUserJoinRequestService userJoinRequestService,
                            TeamUserService userService)
         {
             _participantService = participantService;
             _teamRepository = teamRepository;
             _userService = userService;
-            _userJoinRequestService = userJoinRequestService;
         }
 
         public async Task<Result<Team>> CreateTeam(CancellationToken ct, string name, string description, string[] tags, ICurrentUserProvider currentUserProvider)

--- a/features/team/server/Garnet.Teams.Application/TeamUserJoinRequestService.cs
+++ b/features/team/server/Garnet.Teams.Application/TeamUserJoinRequestService.cs
@@ -91,5 +91,10 @@ namespace Garnet.Teams.Application
             var userJoinRequests = await _userJoinRequestRepository.GetAllUserJoinRequestsByTeam(ct, teamId);
             return Result.Ok(userJoinRequests);
         }
+
+        public async Task DeleteUserJoinRequestsByTeam(CancellationToken ct, string teamId)
+        {
+            await _userJoinRequestRepository.DeleteUserJoinRequestsByTeam(ct, teamId);
+        }
     }
 }

--- a/features/team/server/Garnet.Teams.Infrastructure/Api/TeamsMutation.cs
+++ b/features/team/server/Garnet.Teams.Infrastructure/Api/TeamsMutation.cs
@@ -16,11 +16,16 @@ namespace Garnet.Teams.Infrastructure.Api
     {
         private readonly TeamService _teamService;
         private readonly TeamUserJoinRequestService _membershipService;
+        private readonly TeamDeleteUnitOfWork _teamDeleteUnitOfWork;
 
-        public TeamsMutation(TeamService teamService, TeamUserJoinRequestService membershipService)
+        public TeamsMutation(
+            TeamService teamService,
+            TeamUserJoinRequestService membershipService,
+            TeamDeleteUnitOfWork teamDeleteUnitOfWork)
         {
             _teamService = teamService;
             _membershipService = membershipService;
+            _teamDeleteUnitOfWork = teamDeleteUnitOfWork;
         }
 
         public async Task<TeamCreatePayload> TeamCreate(CancellationToken ct, ClaimsPrincipal claims, TeamCreateInput input)
@@ -34,7 +39,7 @@ namespace Garnet.Teams.Infrastructure.Api
 
         public async Task<TeamDeletePayload> TeamDelete(CancellationToken ct, ClaimsPrincipal claims, string teamId)
         {
-            var result = await _teamService.DeleteTeam(ct, teamId, new CurrentUserProvider(claims));
+            var result = await _teamDeleteUnitOfWork.DeleteTeam(ct, new CurrentUserProvider(claims), teamId);
             result.ThrowQueryExceptionIfHasErrors();
 
             var team = result.Value;

--- a/features/team/server/Garnet.Teams.Infrastructure/MongoDb/TeamParticipantRepository.cs
+++ b/features/team/server/Garnet.Teams.Infrastructure/MongoDb/TeamParticipantRepository.cs
@@ -24,15 +24,12 @@ namespace Garnet.Teams.Infrastructure.MongoDb
             return TeamParticipantDocument.ToDomain(teamParticipant);
         }
 
-        public async Task<TeamParticipant[]> DeleteTeamParticipants(CancellationToken ct, string teamId)
+        public async Task DeleteParticipantsByTeam(CancellationToken ct, string teamId)
         {
             var db = _dbFactory.Create();
-            var participants = await GetParticipantsFromTeam(ct, teamId);
             await db.TeamParticipants.DeleteManyAsync(
                 _f.Eq(x => x.TeamId, teamId)
             );
-
-            return participants;
         }
 
         public async Task<TeamParticipant[]> GetParticipantsFromTeam(CancellationToken ct, string teamId)

--- a/features/team/server/Garnet.Teams.Infrastructure/MongoDb/TeamUserJoinRequestRepository.cs
+++ b/features/team/server/Garnet.Teams.Infrastructure/MongoDb/TeamUserJoinRequestRepository.cs
@@ -28,6 +28,26 @@ namespace Garnet.Teams.Infrastructure.MongoDb
             return TeamUserJoinRequestDocument.ToDomain(joinRequest);
         }
 
+        public async Task DeleteUserJoinRequestsByTeam(CancellationToken ct, string teamId)
+        {
+            var db = _dbFactory.Create();
+            await db.TeamUserJoinRequest.DeleteManyAsync(
+                _f.Eq(x => x.TeamId, teamId),
+                cancellationToken: ct
+            );
+        }
+
+        public async Task<TeamUserJoinRequest?> DeleteUserJoinRequestById(CancellationToken ct, string userJoinRequestId)
+        {
+            var db = _dbFactory.Create();
+            var joinRequest = await db.TeamUserJoinRequest.FindOneAndDeleteAsync(
+                _f.Eq(x => x.Id, userJoinRequestId),
+                cancellationToken: ct
+            );
+
+            return joinRequest is null ? null : TeamUserJoinRequestDocument.ToDomain(joinRequest);
+        }
+
         public async Task<TeamUserJoinRequest[]> GetAllUserJoinRequestsByTeam(CancellationToken ct, string teamId)
         {
             var db = _dbFactory.Create();

--- a/features/team/server/Garnet.Teams/Startup.cs
+++ b/features/team/server/Garnet.Teams/Startup.cs
@@ -42,6 +42,8 @@ namespace Garnet.Team
             services.AddScoped<ITeamParticipantRepository, TeamParticipantRepository>();
             services.AddScoped<ITeamUserRepository, TeamUserRepository>();
             services.AddScoped<ITeamUserJoinRequestRepository, TeamUserJoinRequestRepository>();
+
+            services.AddScoped<TeamDeleteUnitOfWork>();
         }
         private static void AddRepeatableMigrations(this IServiceCollection services)
         {


### PR DESCRIPTION
Убрать в сервисах зависимости от других сервисов по операции
В сервисах оставить только бизнес логику и доменные ошибки, связанные с сущностью сервиса
Например, TeamUserIsAlreadyAParticipantError в TeamUserJoinRequestService.CreateJoinRequestByUser() выносить в unit of work