### PR TITLE
feat/frontend-deploy

### DIFF
--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -1,0 +1,34 @@
+name: Deploy stage
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Connect, pull from repo and restart docker
+        uses: appleboy/ssh-action@v1.0.0
+        env:
+          REMOTE_DIR: '/var/www/app/'
+          DOCKER_COMPOSE_NAME: 'docker-compose.stage.yml'
+          GIT_CONNECT: 'git@github.com:habralab/garnet-team.git'
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          password: ${{ secrets.PASSWORD }}
+          debug: true
+          script_stop: true
+          envs: REMOTE_DIR,DOCKER_COMPOSE_NAME,GIT_CONNECT
+          script: |
+            eval `ssh-agent -s`
+            ssh-add ~/.ssh/garnet_web_repo
+            cd $REMOTE_DIR
+            git pull $GIT_CONNECT
+            docker-compose -f $DOCKER_COMPOSE_NAME down && docker-compose -f $DOCKER_COMPOSE_NAME up --force-recreate --build -d
+            exit 0;

--- a/config/ory/kratos/kratos.yaml
+++ b/config/ory/kratos/kratos.yaml
@@ -4,12 +4,13 @@ dsn: memory
 
 serve:
   public:
-    base_url: http://localhost:4433/
+    base_url: https://https://stage.garnet.pet-project.habr.com:4433/
     cors:
       enabled: true
       allowed_origins:
         - http://localhost:3000
         - http://identity:3000
+        - http://app:3001
         - http://localhost:4455
         - http://oathkeeper:4455
         - http://localhost:4466

--- a/config/ory/oathkeeper/access-rules.yaml
+++ b/config/ory/oathkeeper/access-rules.yaml
@@ -1,8 +1,8 @@
 - id: auth
   upstream:
-    url: http://localhost:3000/
+    url: http://identity:3000/
   match:
-    url: http://<127.0.0.1|localhost>:4455/<(?!app|admin).*>
+    url: https://stage.garnet.pet-project.habr.com/<(?!app|admin).*>
     methods:
       - GET
       - POST
@@ -20,9 +20,9 @@
 
 - id: app
   upstream:
-    url: http://localhost:3000/app
+    url: http://app:3001/
   match:
-    url: http://<127.0.0.1|localhost>:4455/app<.*>
+    url: https://stage.garnet.pet-project.habr.com/<.*>
     methods:
       - GET
       - POST
@@ -30,7 +30,7 @@
       - DELETE
       - PATCH
   authenticators:
-    - handler: anonymous
+    - handler: cookie_session
   authorizer:
     handler: allow
   mutators:

--- a/config/ory/oathkeeper/oathkeeper.yaml
+++ b/config/ory/oathkeeper/oathkeeper.yaml
@@ -82,7 +82,7 @@ errors:
     redirect:
       enabled: true
       config:
-        to: http://localhost:4455/auth/login
+        to: http://identity:4455/auth/login
         when:
           - error:
               - unauthorized

--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -1,0 +1,12 @@
+api:
+  dashboard: true
+  insecure: true
+
+providers:
+  docker: {}
+
+entryPoints:
+  web:
+    address: ':80'
+  websecure:
+    address: ':443'

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,0 +1,151 @@
+version: '3.3'
+
+networks:
+  internal:
+    external: false
+  habralab-stage:
+    external: true
+
+services:
+  yarn:
+    image: node:18.13
+    working_dir: /workspace
+    volumes:
+      - ./:/workspace
+    entrypoint: yarn
+    labels:
+      - 'traefik.enable=false'
+    networks:
+      - internal
+
+  proxy:
+    image: traefik:v3.0
+    ports:
+      - '443:443'
+      - '8080:8080'
+    volumes:
+      - '/var/run/docker.sock:/var/run/docker.sock:ro'
+      - type: bind
+        source: ./config/traefik/traefik.yml
+        target: /traefik.yml
+    networks:
+      - habralab-stage
+      - internal
+
+  oathkeeper:
+    image: oryd/oathkeeper:v0.40.6
+    command: serve --config /config/oathkeeper/oathkeeper.yml
+    volumes:
+      - type: bind
+        source: ./config/ory/oathkeeper
+        target: /config/oathkeeper
+    networks:
+      - internal
+    ports:
+      - '4455:4455'
+      - '4456:4456'
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.middlewares.redirect-identity.redirectscheme.scheme=https'
+      - 'traefik.http.middlewares.redirect-identity.redirectscheme.permanent=true'
+      - 'traefik.http.routers.identity.entrypoints=websecure'
+      - 'traefik.http.routers.identity.rule=Host(`stage.garnet.pet-project.habr.com`) && 
+      PathPrefix(`identity`)'
+      - 'traefik.http.routers.identity.tls=true'
+      - 'traefik.port=443'
+      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Origin=*'
+      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Methods=POST, GET, OPTIONS'
+      - 'traefik.http.routers.identity.middlewares=cor,redirect-identity'
+
+  identity:
+    restart: unless-stopped
+    image: node:18.13
+    working_dir: /workspace
+    entrypoint: yarn workspace @identity/renderer-entrypoint dev
+    volumes:
+      - ./:/workspace
+    ports:
+      - '3000:3000'
+    depends_on:
+      - yarn
+      - kratos
+    networks:
+      - internal
+    labels:
+      - 'traefik.enable=false'
+
+  app:
+    restart: unless-stopped
+    image: node:18.13
+    working_dir: /workspace
+    labels:
+      - 'traefik.enable=false'
+    volumes:
+      - ./:/workspace
+    entrypoint: yarn workspace @app/renderer-entrypoint dev
+    ports:
+      - '3001:3001'
+    depends_on:
+      - yarn
+    networks:
+      - internal
+
+  kratos:
+    depends_on:
+      - kratos-migrate
+      - db
+    image: oryd/kratos:v1.0.0
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.app.entrypoints=websecure'
+      - 'traefik.http.routers.app.rule=Host(`stage.garnet.pet-project.habr.com`)'
+      - 'traefik.http.routers.app.tls=true'
+      - 'traefik.port=443'
+      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Origin=*'
+      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Methods=POST, GET, OPTIONS'
+      - 'traefik.http.routers.app.middlewares=cor,redirect-app'
+
+    ports:
+      - '4433:4433'
+    restart: unless-stopped
+    environment:
+      - DSN=postgres://postgres:password@db:5432/db?sslmode=disable&max_conns=20&max_idle_conns=4
+      - LOG_LEVEL=trace
+    command: serve -c /config/kratos/kratos.yaml --dev --watch-courier
+    volumes:
+      - type: bind
+        source: ./config/ory/kratos
+        target: /config/kratos
+    networks:
+      - internal
+
+  kratos-migrate:
+    depends_on:
+      - db
+    image: docker.io/oryd/kratos:v1.0.0
+    labels:
+      - 'traefik.enable=false'
+    environment:
+      - DSN=postgres://postgres:password@db:5432/db?sslmode=disable&max_conns=20&max_idle_conns=4
+    volumes:
+      - type: bind
+        source: ./config/ory/kratos
+        target: /config/kratos
+    command: -c /config/kratos/kratos.yaml migrate sql -e --yes
+    restart: on-failure
+    networks:
+      - internal
+
+  db:
+    image: bitnami/postgresql
+    restart: unless-stopped
+    labels:
+      - 'traefik.enable=false'
+    environment:
+      - POSTGRESQL_PASSWORD=password
+      - POSTGRESQL_DATABASE=db
+      - POSTGRESQL_USER=postgres
+    ports:
+      - '5432:5432'
+    networks:
+      - internal


### PR DESCRIPTION
- добавлен `docker-compose` для запуска в стейдже
- в деплое будет использоваться `traefik` как прокси входящих запросов, `oathkeeper` для распределения запросов по внутренней сети