### PR TITLE
#198: Настройка деплоя ory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY ["common/server", "common/server"]
 COPY ["features/project/server", "features/project/server"]
 COPY ["features/team/server", "features/team/server"]
 COPY ["features/user/server", "features/user/server"]
+COPY ["features/notification/server", "features/notification/server"]
 RUN dotnet restore "common/server/Garnet/Garnet.csproj"
 RUN dotnet build "common/server/Garnet/Garnet.csproj" -c Release -o /app/build --no-restore
 

--- a/config/deploy.prod.yml
+++ b/config/deploy.prod.yml
@@ -1,5 +1,7 @@
 servers:
-  - 188.225.36.16
+  web:
+    hosts:
+      - 188.225.36.16
 
 accessories:
   db:

--- a/config/deploy.stage.yml
+++ b/config/deploy.stage.yml
@@ -1,5 +1,7 @@
 servers:
-  - 85.92.110.73
+  web:
+    hosts:
+      - 85.92.110.73
 
 accessories:
   db:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -2,6 +2,11 @@ service: garnet-backend
 
 image: picolino/garnet-backend
 
+servers:
+  web:
+    options:
+      network: app_garnet
+
 env:
   secret:
     - MONGO_CONNSTRING
@@ -34,6 +39,8 @@ accessories:
         - MONGO_INITDB_ROOT_PASSWORD
     directories:
       - data:/data/db
+    options:
+      network: app_garnet
 
 traefik:
   options:
@@ -41,6 +48,7 @@ traefik:
       - '443:443'
     volume:
       - traefik:/configuration
+    network: app_garnet
   args:
     entryPoints.web.address: ':80'
     entryPoints.websecure.address: ':443'

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -26,7 +26,7 @@ services:
       - '4456:4456'
     labels:
       - 'traefik.http.routers.oathkeeper-app.entrypoints=websecure'
-      - 'traefik.http.routers.oathkeeper-app.rule=Host(`stage.garnet.pet-project.habr.com`) && PathPrefix(`/oath`)'
+      - 'traefik.http.routers.oathkeeper-app.rule=Host(`stage.garnet.pet-project.habr.com`)'
       - 'traefik.http.routers.oathkeeper-app.tls=true'
       - 'traefik.http.routers.oathkeeper-app.middlewares=cor'
       - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Origin=*'

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -1,8 +1,9 @@
 version: '3.3'
 
 networks:
-  bridge:
-    external: true
+  internal:
+    internal: true
+  garnet:
 
 services:
   yarn:
@@ -11,7 +12,8 @@ services:
     volumes:
       - ./:/workspace
     entrypoint: yarn
-    network_mode: bridge
+    networks:
+      - internal
 
   oathkeeper:
     image: oryd/oathkeeper:v0.40.6
@@ -20,7 +22,6 @@ services:
       - ./config/ory/oathkeeper/oathkeeper.yaml:/config/oathkeeper/oathkeeper.yaml
       - ./config/ory/oathkeeper/jwks.json:/config/oathkeeper/jwks.json
       - ./config/ory/oathkeeper/access-rules.yaml:/config/oathkeeper/access-rules.yaml
-    network_mode: bridge
     ports:
       - '4455:4455'
       - '4456:4456'
@@ -31,6 +32,9 @@ services:
       - 'traefik.http.routers.oathkeeper-app.middlewares=cor'
       - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Origin=*'
       - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Methods=POST, GET, OPTIONS'
+    networks:
+      - garnet
+      - internal
 
   identity:
     restart: unless-stopped
@@ -44,7 +48,8 @@ services:
     depends_on:
       - yarn
       - kratos
-    network_mode: bridge
+    networks:
+      - internal
 
   app:
     restart: unless-stopped
@@ -57,7 +62,8 @@ services:
       - '3020:3020'
     depends_on:
       - yarn
-    network_mode: bridge
+    networks:
+      - internal
 
   kratos:
     depends_on:
@@ -75,7 +81,8 @@ services:
       - type: bind
         source: ./config/ory/kratos
         target: /config/kratos
-    network_mode: bridge
+    networks:
+      - internal
 
   kratos-migrate:
     depends_on:
@@ -89,7 +96,8 @@ services:
         target: /config/kratos
     command: -c /config/kratos/kratos.yaml migrate sql -e --yes
     restart: on-failure
-    network_mode: bridge
+    networks:
+      - internal
 
   db:
     image: bitnami/postgresql
@@ -100,4 +108,5 @@ services:
       - POSTGRESQL_USER=postgres
     ports:
       - '5432:5432'
-    network_mode: bridge
+    networks:
+      - internal

--- a/docker-compose.stage.yml
+++ b/docker-compose.stage.yml
@@ -11,8 +11,6 @@ services:
     volumes:
       - ./:/workspace
     entrypoint: yarn
-    labels:
-      - 'traefik.enable=false'
     network_mode: bridge
 
   oathkeeper:
@@ -27,7 +25,6 @@ services:
       - '4455:4455'
       - '4456:4456'
     labels:
-      - 'traefik.enable=true'
       - 'traefik.http.routers.oathkeeper-app.entrypoints=websecure'
       - 'traefik.http.routers.oathkeeper-app.rule=Host(`stage.garnet.pet-project.habr.com`) && PathPrefix(`/oath`)'
       - 'traefik.http.routers.oathkeeper-app.tls=true'
@@ -48,18 +45,11 @@ services:
       - yarn
       - kratos
     network_mode: bridge
-    labels:
-      - 'traefik.enable=true'
-      - 'traefik.http.routers.identity-app.entrypoints=websecure'
-      - 'traefik.http.routers.identity-app.rule=Host(`stage.garnet.pet-project.habr.com`)'
-      - 'traefik.http.routers.identity-app.tls=true'
 
   app:
     restart: unless-stopped
     image: node:18.13
     working_dir: /workspace
-    labels:
-      - 'traefik.enable=true'
     volumes:
       - ./:/workspace
     entrypoint: yarn workspace @app/renderer-entrypoint dev
@@ -74,14 +64,6 @@ services:
       - kratos-migrate
       - db
     image: oryd/kratos:v1.0.0
-    labels:
-      - 'traefik.enable=false'
-      - 'traefik.http.routers.kratos-app.entrypoints=websecure'
-      - 'traefik.http.routers.kratos-app.rule=Host(`stage.garnet.pet-project.habr.com`) && PathPrefix(`/kratos`)'
-      - 'traefik.http.routers.kratos-app.tls=true'
-      - 'traefik.http.routers.kratos-app.middlewares=cor'
-      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Origin=*'
-      - 'traefik.http.middlewares.cor.headers.customResponseHeaders.Access-Control-Allow-Methods=POST, GET, OPTIONS'
     ports:
       - '4433:4433'
     restart: unless-stopped
@@ -99,8 +81,6 @@ services:
     depends_on:
       - db
     image: docker.io/oryd/kratos:v1.0.0
-    labels:
-      - 'traefik.enable=false'
     environment:
       - DSN=postgres://postgres:password@db:5432/db?sslmode=disable&max_conns=20&max_idle_conns=4
     volumes:
@@ -114,8 +94,6 @@ services:
   db:
     image: bitnami/postgresql
     restart: unless-stopped
-    labels:
-      - 'traefik.enable=false'
     environment:
       - POSTGRESQL_PASSWORD=password
       - POSTGRESQL_DATABASE=db


### PR DESCRIPTION
- Убраны лишние настройки для traefik
- Основной эндпоинт приложения (/) ведет на oath.
- Остальные ресурсы недоступны из-вне.

**Конфигурация из PR задеплоена на stage.**

Пришлось заменить дефолтную bridge сеть на кастомные две, чтобы иметь возможность обращаться к соседним контейнерам по алиасу.

Пруфы наличия доступа (internal сеть):
![image](https://github.com/habralab/garnet-team/assets/17460456/f5dd5adc-16df-457d-9964-7835966664e1)

Пруфы наличия доступа (из garnet сети - от traefik):
![image](https://github.com/habralab/garnet-team/assets/17460456/97fdddba-ab03-4711-95eb-1afd522b8699)

Пруфы отсутствия доступа из garnet сети к internal сети:
![image](https://github.com/habralab/garnet-team/assets/17460456/11d3c3fb-4922-4de7-9108-c9e0cdd59fb8)


